### PR TITLE
Update eZ Platform to v2.5.6

### DIFF
--- a/templates/ezplatform.template.yaml
+++ b/templates/ezplatform.template.yaml
@@ -6,9 +6,9 @@ info:
     # Unique machine name, prefaced by a vendor or organization identifier
     id: ezsystems/ezplatform
     # The human-readable name of the template.
-    name: eZ Platform 2.5.5
+    name: eZ Platform v2
     # Human-readable descriptive text for the template. Supports limited HTML.
-    description: The latest version of <b>eZ Platform</b> without customization. Good for starting a new project.
+    description: The latest version of <b>eZ Platform</b> (v2.5.6) without customization. Good for starting a new project.
     # A list of tags associated with the template.
     tags:
         - PHP
@@ -31,7 +31,7 @@ info:
 # this key also gets mapped to the appropriate location in project.settings so
 # that the current UI can have its own workflow overridden as well.
 initialize:
-    repository: git://github.com/ezsystems/ezplatform.git@v2.5.5
+    repository: git://github.com/ezsystems/ezplatform.git@v2.5.6
     config: null
     files: []
-    profile: eZ Platform v2.5.5
+    profile: eZ Platform v2


### PR DESCRIPTION
We released eZ Platform 2.5.6 last week. 🎉 
This is the update for the meta repo. Demo will come soon.
