### PR TITLE
Symfony fix

### DIFF
--- a/templates/ezplatform.template.yaml
+++ b/templates/ezplatform.template.yaml
@@ -38,7 +38,7 @@ info:
 # this key also gets mapped to the appropriate location in project.settings so
 # that the current UI can have its own workflow overridden as well.
 initialize:
-    repository: git://github.com/ezsystems/ezplatform.git@v2.5.25
+    repository: https://github.com/ezsystems/ezplatform.git@v2.5.25
     config: null
     files: []
     profile: eZ Platform v2

--- a/templates/openideal.template.yaml
+++ b/templates/openideal.template.yaml
@@ -37,7 +37,7 @@ info:
 # this key also gets mapped to the appropriate location in project.settings so
 # that the current UI can have its own workflow overridden as well.
 initialize:
-  repository: git://github.com/linnovate/openideal-on-platformsh.git@master
+  repository: https://github.com/linnovate/openideal-on-platformsh.git@master
   config: null
   files: []
   profile: OpenideaL

--- a/templates/pizzly.yaml
+++ b/templates/pizzly.yaml
@@ -35,7 +35,7 @@ info:
 # this key also gets mapped to the appropriate location in project.settings so
 # that the current UI can have its own workflow overridden as well.
 initialize:
-    repository: git://github.com/Bearer/Pizzly.git
+    repository: https://github.com/Bearer/Pizzly.git
     config: null
     files: []
     profile: Pizzly

--- a/templates/redirection-io.template.yaml
+++ b/templates/redirection-io.template.yaml
@@ -23,7 +23,7 @@ info:
           content: "golang 1.15"
 
 initialize:
-    repository: git://github.com/redirectionio/platformsh-template.git@master
+    repository: https://github.com/redirectionio/platformsh-template.git@master
     config: null
     files: []
     profile: redirection.io

--- a/templates/symfony-5.4-php8.0-base.template.yaml
+++ b/templates/symfony-5.4-php8.0-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.0<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.0-base
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.0-base
   config: null
   files: []
   profile: Symfony 5.4 ("base skeleton" on PHP 8.0)

--- a/templates/symfony-5.4-php8.0-base.template.yaml
+++ b/templates/symfony-5.4-php8.0-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.0<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@5.4-php8.0-base
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.0-base
   config: null
   files: []
   profile: Symfony 5.4 ("base skeleton" on PHP 8.0)

--- a/templates/symfony-5.4-php8.0-webapp.template.yaml
+++ b/templates/symfony-5.4-php8.0-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.0-webapp
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.0-webapp
   config: null
   files: []
   profile: Symfony 5.4 ("webapp" on PHP 8.0)

--- a/templates/symfony-5.4-php8.0-webapp.template.yaml
+++ b/templates/symfony-5.4-php8.0-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@5.4-php8.0-webapp
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.0-webapp
   config: null
   files: []
   profile: Symfony 5.4 ("webapp" on PHP 8.0)

--- a/templates/symfony-5.4-php8.1-base.template.yaml
+++ b/templates/symfony-5.4-php8.1-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.1<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.1-base
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.1-base
   config: null
   files: []
   profile: Symfony 5.4 ("base skeleton" on PHP 8.1)

--- a/templates/symfony-5.4-php8.1-base.template.yaml
+++ b/templates/symfony-5.4-php8.1-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.1<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@5.4-php8.1-base
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.1-base
   config: null
   files: []
   profile: Symfony 5.4 ("base skeleton" on PHP 8.1)

--- a/templates/symfony-5.4-php8.1-webapp.template.yaml
+++ b/templates/symfony-5.4-php8.1-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@5.4-php8.1-webapp
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.1-webapp
   config: null
   files: []
   profile: Symfony 5.4 ("webapp" on PHP 8.1)

--- a/templates/symfony-5.4-php8.1-webapp.template.yaml
+++ b/templates/symfony-5.4-php8.1-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.1-webapp
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf5.4-php8.1-webapp
   config: null
   files: []
   profile: Symfony 5.4 ("webapp" on PHP 8.1)

--- a/templates/symfony-6.0-php8.0-base.template.yaml
+++ b/templates/symfony-6.0-php8.0-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.0<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-base
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-base
   config: null
   files: []
   profile: Symfony 6.0 ("base skeleton" on PHP 8.0)

--- a/templates/symfony-6.0-php8.0-base.template.yaml
+++ b/templates/symfony-6.0-php8.0-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.0<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@6.0-php8.0-base
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-base
   config: null
   files: []
   profile: Symfony 6.0 ("base skeleton" on PHP 8.0)

--- a/templates/symfony-6.0-php8.0-demo.template.yaml
+++ b/templates/symfony-6.0-php8.0-demo.template.yaml
@@ -20,7 +20,7 @@ info:
           PHP 8.0<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-demo
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-demo
   config: null
   files: []
   profile: Symfony 6.0 ("demo" on PHP 8.0)

--- a/templates/symfony-6.0-php8.0-demo.template.yaml
+++ b/templates/symfony-6.0-php8.0-demo.template.yaml
@@ -20,7 +20,7 @@ info:
           PHP 8.0<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@6.0-php8.0-demo
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-demo
   config: null
   files: []
   profile: Symfony 6.0 ("demo" on PHP 8.0)

--- a/templates/symfony-6.0-php8.0-webapp.template.yaml
+++ b/templates/symfony-6.0-php8.0-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-webapp
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-webapp
   config: null
   files: []
   profile: Symfony 6.0 ("webapp" on PHP 8.0)

--- a/templates/symfony-6.0-php8.0-webapp.template.yaml
+++ b/templates/symfony-6.0-php8.0-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@6.0-php8.0-webapp
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.0-webapp
   config: null
   files: []
   profile: Symfony 6.0 ("webapp" on PHP 8.0)

--- a/templates/symfony-6.0-php8.1-base.template.yaml
+++ b/templates/symfony-6.0-php8.1-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.1<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@6.0-php8.1-base
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-base
   config: null
   files: []
   profile: Symfony 6.0 ("base skeleton" on PHP 8.1)

--- a/templates/symfony-6.0-php8.1-base.template.yaml
+++ b/templates/symfony-6.0-php8.1-base.template.yaml
@@ -21,7 +21,7 @@ info:
           PHP 8.1<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-base
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-base
   config: null
   files: []
   profile: Symfony 6.0 ("base skeleton" on PHP 8.1)

--- a/templates/symfony-6.0-php8.1-demo.template.yaml
+++ b/templates/symfony-6.0-php8.1-demo.template.yaml
@@ -20,7 +20,7 @@ info:
           PHP 8.1<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-demo
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-demo
   config: null
   files: []
   profile: Symfony 6.0 ("demo" on PHP 8.1)

--- a/templates/symfony-6.0-php8.1-demo.template.yaml
+++ b/templates/symfony-6.0-php8.1-demo.template.yaml
@@ -20,7 +20,7 @@ info:
           PHP 8.1<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@6.0-php8.1-demo
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-demo
   config: null
   files: []
   profile: Symfony 6.0 ("demo" on PHP 8.1)

--- a/templates/symfony-6.0-php8.1-webapp.template.yaml
+++ b/templates/symfony-6.0-php8.1-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-webapp
+  repository: https://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-webapp
   config: null
   files: []
   profile: Symfony 6.0 ("webapp" on PHP 8.1)

--- a/templates/symfony-6.0-php8.1-webapp.template.yaml
+++ b/templates/symfony-6.0-php8.1-webapp.template.yaml
@@ -22,7 +22,7 @@ info:
           PostgreSQL 13<br />
           Automatic TLS certificates<br />
 initialize:
-  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@6.0-php8.1-webapp
+  repository: git://github.com/symfonycorp/platformsh-symfony-template.git@sf6.0-php8.1-webapp
   config: null
   files: []
   profile: Symfony 6.0 ("webapp" on PHP 8.1)


### PR DESCRIPTION
Two fixes:

- symfony branch targets were missing the `sf` prefix, i.e. https://github.com/symfonycorp/platformsh-symfony-template/tree/sf5.4-php8.0-base
- Fix for the deprecated `git://` protocol https://github.blog/2021-09-01-improving-git-protocol-security-github/