### PR TITLE
Update varbase.template.yaml to PHP 8.1

### DIFF
--- a/templates/varbase.template.yaml
+++ b/templates/varbase.template.yaml
@@ -25,7 +25,7 @@ info:
   notes:
     - heading: "Features"
       content: |
-        PHP 7.3<br />
+        PHP 8.1<br />
         MariaDB 10.4<br />
         Redis 6<br />
         Drush included<br />


### PR DESCRIPTION
- Updated Platform.sh app configs for [Vardot/platformsh-varbase](https://github.com/Vardot/platformsh-varbase) template to use PHP 8.1 [#35](https://github.com/Vardot/platformsh-varbase/pull/35)
- Updated Lando project configs for [Vardot/varbase-project](https://github.com/Vardot/varbase-project) template to use PHP 8.1 [#154](https://github.com/Vardot/varbase-project/pull/154)

https://github.com/Vardot/platformsh-varbase/blob/master/.platform.app.yaml#L10 
