### PR TITLE
Change default PHP version to PHP 8.2 for Platform.sh Varbase project template

### DIFF
--- a/templates/varbase.template.yaml
+++ b/templates/varbase.template.yaml
@@ -25,7 +25,7 @@ info:
   notes:
     - heading: "Features"
       content: |
-        PHP 8.1<br />
+        PHP 8.2<br />
         MariaDB 10.4<br />
         Redis 6<br />
         Drush included<br />


### PR DESCRIPTION
Changed default PHP version to `PHP 8.2` for **Platform.sh Varbase project**  template [#19](https://github.com/Vardot/platformsh-varbase/issues/19)
